### PR TITLE
x64 JIT: Fix memory reads/writes on Windows

### DIFF
--- a/src/jit_no_ir.h
+++ b/src/jit_no_ir.h
@@ -565,12 +565,12 @@ public:
         c.sub(rsp, 64);
         c.and_(rsp, ~0xF);
 
-        c.mov(ABI_PARAM1, reinterpret_cast<uintptr_t>(&mem));
         if constexpr (std::is_base_of_v<Xbyak::Reg, T>) {
             c.movzx(ABI_PARAM2, addr.cvt16());
         } else {
             c.mov(ABI_PARAM2, addr & 0xFFFF);
         }
+        c.mov(ABI_PARAM1, reinterpret_cast<uintptr_t>(&mem));
         CallFarFunction(c, MemDataReadThunk);
 
                // Undo anything we did
@@ -2823,13 +2823,13 @@ public:
         c.sub(rsp, 64);
         c.and_(rsp, ~0xF);
 
-        c.mov(ABI_PARAM1, reinterpret_cast<uintptr_t>(&mem));
         if constexpr (std::is_base_of_v<Xbyak::Reg, T1>) {
             c.movzx(ABI_PARAM2, addr.cvt16());
         } else {
             c.mov(ABI_PARAM2, addr);
         }
         c.mov(ABI_PARAM3, value);
+        c.mov(ABI_PARAM1, reinterpret_cast<uintptr_t>(&mem));
         CallFarFunction(c, MemDataWriteThunk);
 
                // Undo anything we did


### PR DESCRIPTION
This is more of a band-aid patch and not really the best way of solving it, but at least some things can boot to a point on Windows now

Might be good to test on Linux too but I don't think this change should break Linux in any way