### PR TITLE
Add block key masking

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,7 +60,7 @@ add_library(teakra
 
 create_target_directory_groups(teakra)
 
-target_link_libraries(teakra PRIVATE Threads::Threads boost tsl::robin_map xbyak::xbyak)
+target_link_libraries(teakra PRIVATE Threads::Threads tsl::robin_map xbyak::xbyak)
 target_include_directories(teakra
                            PUBLIC ../include
                            PRIVATE .)


### PR DESCRIPTION
Having so much state in the block key leads to cases where a block is compiled multiple times even though the actual emitted code is the same. Not every block uses all of the state provided by the key. To address this each time a block is compiled a mask of used registers is also emitted. This matches well with the switch to the lookup table as the mask is inherently location specific.

Block key state is accessed through methods that automatically mask the appropriate member, so this wont break in the future if we forget to manually mask during block generation. It leads to about a 5x reduction in compiled blocks (from 6000 to 1500 during first 10 seconds if 3D Land intro in Surround Sound mode). The max lookup iteration also dropped from 15 to 7 meaning the dispatcher is now faster too.

Initially I wanted to optimize the key matching using AVX2 intrinsics like so, which generates very good asm, but it seems to cause crashes most of the time launching which I'm not sure why
```
bool KeyCompare(const Key& lhs, const Key& rhs, u256 mask_lo, u256 mask_hi) {
    const u256* lhsp = (const u256*)&lhs;
    const u256* rhsp = (const u256*)&rhs;
    const u256 l = _mm256_cmpeq_epi16(_mm256_and_si256(lhsp[0], mask_lo), rhsp[0]);
    const u256 r = _mm256_cmpeq_epi16(_mm256_and_si256(lhsp[1], mask_hi), rhsp[1]);
    return (_mm256_movemask_epi8(l) & _mm256_movemask_epi8(r)) == std::numeric_limits<u32>::max();
}
```