### PR TITLE
Properly use add_subdirectory for robin-map

### DIFF
--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -7,3 +7,7 @@ endif()
 if (NOT TARGET xbyak::xbyak)
     add_subdirectory(xbyak)
 endif()
+
+if (NOT TARGET tsl::robin_map)
+    add_subdirectory(robin-map)
+endif()


### PR DESCRIPTION
The project links with robin-map but doesn't actually call add_subdirectory on it, so the build was broken outside of emulators that already included it by themselves